### PR TITLE
Make this library compile on non-Linux systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The only case the uniqueness of the UUID could be violated is if two machines
 have the same hostname and booted up at the exact same second in time, but it is
 bad practice to give machines the same hostname (so don't).
 
-⚠️ : This library is fully supported on Linux systems _only_. Using this
+⚠️: This library is fully supported on Linux systems _only_. Using this
 library on non Linux system will compile but most likely will not work
 as intended. Use on non Linux systems at your own risk.
 

--- a/README.md
+++ b/README.md
@@ -10,5 +10,9 @@ The only case the uniqueness of the UUID could be violated is if two machines
 have the same hostname and booted up at the exact same second in time, but it is
 bad practice to give machines the same hostname (so don't).
 
+⚠️ : This library is fully supported on Linux systems _only_. Using this
+library on non Linux system will compile but most likely will not work
+as intended. Use on non Linux systems at your own risk.
+
 The design of the UUIDs and this system for creating them can be found in
 [`DESIGN.md`](https://github.com/m-lab/uuid/blob/master/DESIGN.md).

--- a/socookie/socookie.go
+++ b/socookie/socookie.go
@@ -1,0 +1,17 @@
+// Package socookie allows to get a socket's cookie.
+package socookie
+
+import (
+	"os"
+)
+
+// Get returns the cookie (the UUID) associated with a socket. For a given
+// boot of a given hostname, this UUID is guaranteed to be unique (until the
+// host receives more than 2^64 connections without rebooting).
+//
+// The implementation for Linux uses kernel support for getting the
+// cookie. The implementation for other platforms does not and therefore
+// cannot be relied upon; use it at your own risk.
+func Get(file *os.File) (uint64, error) {
+	return get(file)
+}

--- a/socookie/socookie_linux.go
+++ b/socookie/socookie_linux.go
@@ -1,0 +1,41 @@
+package socookie
+
+import (
+	"flag"
+	"fmt"
+	"net"
+	"os"
+	"syscall"
+	"unsafe"
+
+	"github.com/m-lab/uuid/prefix"
+
+	"github.com/m-lab/go/flagx"
+)
+
+const (
+	// defined in socket.h in the linux kernel
+	syscallSoCookie = 57 // syscall.SO_COOKIE does not exist in golang 1.11
+)
+
+// get implements Get for Linux systems.
+func get(file *os.File) (uint64, error) {
+	var cookie uint64
+	cookieLen := uint32(unsafe.Sizeof(cookie))
+	// GetsockoptInt does not work for 64 bit integers, which is what the UUID is.
+	// So we crib from the GetsockoptInt implementation and ndt-server/tcpinfox,
+	// and call the syscall manually.
+	_, _, errno := syscall.Syscall6(
+		uintptr(syscall.SYS_GETSOCKOPT),
+		uintptr(int(file.Fd())),
+		uintptr(syscall.SOL_SOCKET),
+		uintptr(syscallSoCookie),
+		uintptr(unsafe.Pointer(&cookie)),
+		uintptr(unsafe.Pointer(&cookieLen)),
+		uintptr(0))
+
+	if errno != 0 {
+		return 0, fmt.Errorf("Error in Getsockopt. Errno=%d", errno)
+	}
+	return cookie, nil
+}

--- a/socookie/socookie_linux.go
+++ b/socookie/socookie_linux.go
@@ -1,16 +1,10 @@
 package socookie
 
 import (
-	"flag"
 	"fmt"
-	"net"
 	"os"
 	"syscall"
 	"unsafe"
-
-	"github.com/m-lab/uuid/prefix"
-
-	"github.com/m-lab/go/flagx"
 )
 
 const (

--- a/socookie/socookie_stub.go
+++ b/socookie/socookie_stub.go
@@ -1,0 +1,16 @@
+// +build !linux
+
+package socookie
+
+import (
+	"os"
+	"sync/atomic"
+)
+
+// cookieGen is the counter we use to emulate SO_COOKIE.
+var cookieGen uint64
+
+// get implements Get for non Linux systems.
+func get(file *os.File) (uint64, error) {
+	return atomic.AddUint64(&cookieGen, uint64(1)), nil
+}


### PR DESCRIPTION
Clarify that we fully support Linux only. On non-Linux systems
this code will not behave as intended.

However, it may still be useful to compile on non-Linux systems
for running smoke testing. (For example, my laptop is a macOS
system and I routinely work on m-lab/ndt-server using it, hence
it's useful for me that this code works on macOS.)

There is no point in sweating to make this code work well for
non-Linux systems, or to make tests pass, because M-Lab is
a Linux based platform. So, this diff is only for convenience.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/uuid/6)
<!-- Reviewable:end -->
