### PR TITLE
Replace Fd() with syscall.RawConn.Control()

### DIFF
--- a/socookie/socookie_linux.go
+++ b/socookie/socookie_linux.go
@@ -21,7 +21,7 @@ func get(file *os.File) (uint64, error) {
 		return 0, err
 	}
 	var errno syscall.Errno
-	rawConn.Control(func(fd uintptr) {
+	err = rawConn.Control(func(fd uintptr) {
 		// GetsockoptInt does not work for 64 bit integers, which is what the UUID is.
 		// So we crib from the GetsockoptInt implementation and ndt-server/tcpinfox,
 		// and call the syscall manually.
@@ -34,6 +34,9 @@ func get(file *os.File) (uint64, error) {
 			uintptr(unsafe.Pointer(&cookieLen)),
 			uintptr(0))
 	})
+	if err != nil {
+		return 0, err
+	}
 	if errno != 0 {
 		return 0, fmt.Errorf("error in Getsockopt. Errno=%d", errno)
 	}

--- a/socookie/socookie_linux.go
+++ b/socookie/socookie_linux.go
@@ -16,20 +16,26 @@ const (
 func get(file *os.File) (uint64, error) {
 	var cookie uint64
 	cookieLen := uint32(unsafe.Sizeof(cookie))
-	// GetsockoptInt does not work for 64 bit integers, which is what the UUID is.
-	// So we crib from the GetsockoptInt implementation and ndt-server/tcpinfox,
-	// and call the syscall manually.
-	_, _, errno := syscall.Syscall6(
-		uintptr(syscall.SYS_GETSOCKOPT),
-		uintptr(int(file.Fd())),
-		uintptr(syscall.SOL_SOCKET),
-		uintptr(syscallSoCookie),
-		uintptr(unsafe.Pointer(&cookie)),
-		uintptr(unsafe.Pointer(&cookieLen)),
-		uintptr(0))
-
+	rawConn, err := file.SyscallConn()
+	if err != nil {
+		return 0, err
+	}
+	var errno syscall.Errno
+	rawConn.Control(func(fd uintptr) {
+		// GetsockoptInt does not work for 64 bit integers, which is what the UUID is.
+		// So we crib from the GetsockoptInt implementation and ndt-server/tcpinfox,
+		// and call the syscall manually.
+		_, _, errno = syscall.Syscall6(
+			uintptr(syscall.SYS_GETSOCKOPT),
+			fd,
+			uintptr(syscall.SOL_SOCKET),
+			uintptr(syscallSoCookie),
+			uintptr(unsafe.Pointer(&cookie)),
+			uintptr(unsafe.Pointer(&cookieLen)),
+			uintptr(0))
+	})
 	if errno != 0 {
-		return 0, fmt.Errorf("Error in Getsockopt. Errno=%d", errno)
+		return 0, fmt.Errorf("error in Getsockopt. Errno=%d", errno)
 	}
 	return cookie, nil
 }


### PR DESCRIPTION
`Fd()` removes the `O_NONBLOCK` flag from the descriptor before returning it.

From [os/file_unix.go](https://github.com/golang/go/blob/master/src/os/file_unix.go#L85):
```
	// If we put the file descriptor into nonblocking mode,
	// then set it to blocking mode before we return it,
	// because historically we have always returned a descriptor
	// opened in blocking mode. The File will continue to work,
	// but any blocking operation will tie up a thread.
```

When `Fd()` is called on a `*os.File` obtained via `conn.File()`, this descriptor is actually a duplicate but the underlying socket is shared. The end result is that the original `conn` still thinks it has a non-blocking socket, while the socket actually became blocking. This causes things like `conn.Close()` blocking forever if no data is received.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/uuid/10)
<!-- Reviewable:end -->
