### PR TITLE
Add uuid client for python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,14 @@ go:
 before_install:
 # Coverage tools
 - go install github.com/mattn/goveralls@latest
+- apt-get update && apt-get install -y python3
 
 script:
 # Build everything and retrieve any component libraries.
 - go get ./...
 # Run every regular unit test.
 - go test -covermode=count -coverprofile=_coverage.cov -v ./...
+- python3 ./python3/uuid_test.py
 # Submit coverage to Coveralls.io
 - $HOME/gopath/bin/goveralls -coverprofile=_coverage.cov -service=travis-ci
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ go:
 before_install:
 # Coverage tools
 - go install github.com/mattn/goveralls@latest
-- apt-get update && apt-get install -y python3
+- sudo apt-get update && sudo apt-get install -y python3
 
 script:
 # Build everything and retrieve any component libraries.

--- a/python3/uuid.py
+++ b/python3/uuid.py
@@ -1,0 +1,59 @@
+"""
+The `uuid` package generates UUID strings from socket cookies.
+
+This package contains a single class, `UUID`, which generates UUID strings from
+socket cookies. The UUID strings are in the format `<PREFIX>_<COOKIE>`, where
+`PREFIX` is a user-defined prefix string read from a file and `COOKIE` is a
+hexadecimal string representation of the socket cookie.
+
+Usage:
+    >>> import socket
+    >>> uuid = UUID("my_prefix.txt")
+    >>> sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    >>> sock.connect(("localhost", 8080))
+    >>> uuid_str = uuid.from_socket(sock)
+    >>> print(uuid_str)
+    my_prefix_1234ABCD
+
+Classes:
+    UUID: A class for generating UUID strings from socket cookies.
+"""
+
+import socket
+
+
+# Static definition of _SO_COOKIE option code.
+_SO_COOKIE = 57
+_COOKIE_LENGTH = 8
+__version__ = "1.0.0"
+
+
+class UUID(object):
+    """Generates UUIDs from socket cookies."""
+
+    def __init__(self, prefix_file):
+        """Creates a new UUID instance.
+
+        Args:
+          prefix_file (str): filename containing uuid prefix.
+
+        Raises:
+          FileNotFoundError: If prefix_file is not found.
+        """
+        with open(prefix_file) as p:
+            self.prefix = p.read().strip()
+
+    def from_socket(self, sock):
+        """Generates a UUID string from the given socket cookie.
+
+        Args:
+          sock (socket.socket): open socket.
+
+        Raises:
+          ValueError: if the returned cookie is wrong length.
+        """
+        cookie = sock.getsockopt(socket.SOL_SOCKET, _SO_COOKIE, _COOKIE_LENGTH)
+        if len(cookie) != _COOKIE_LENGTH:
+            raise ValueError("incomplete cookie")
+        hexcookie = cookie[::-1].hex().upper()
+        return f"{self.prefix}_{hexcookie}"

--- a/python3/uuid_test.py
+++ b/python3/uuid_test.py
@@ -1,0 +1,28 @@
+import os
+import tempfile
+import socket
+import unittest
+from unittest import mock
+
+import uuid
+
+class TestUUID_from_socket(unittest.TestCase):
+    def setUp(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            # Write uuid prefix to temp file.
+            tmpname = os.path.join(tempdir, 'prefix.file')
+            with open(tmpname, 'w') as temp:
+                temp.write("ndt-kps5n_1619746702\n")
+            # Initialize UUID instance.
+            self.uuid = uuid.UUID(tmpname)
+
+    def test_from_socket(self):
+        mock_sock = mock.MagicMock(spec=socket.socket)
+        mock_sock.getsockopt.return_value = b'\xd1\rr\x00\x00\x00\x00\x00'
+
+        s = self.uuid.from_socket(mock_sock)
+
+        self.assertEqual('ndt-kps5n_1619746702_0000000000720DD1', s)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python3/uuid_test.py
+++ b/python3/uuid_test.py
@@ -1,10 +1,10 @@
 import os
-import tempfile
 import socket
+import tempfile
 import unittest
+import uuid
 from unittest import mock
 
-import uuid
 
 class TestUUID_from_socket(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
This change adds a python client for generating M-Lab UUIDs from a given UUID prefix file (produced by M-Lab's init containers) and from a connection socket (provided by the measurement service written with Python).

This package may be helpful for services written in Python that wish to generate UUIDs to associate measurements with other sidecar datatypes, e.g. scamper1 based on the UUID.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/uuid/12)
<!-- Reviewable:end -->
