### PR TITLE
Allow prefix file to be passed in via function call

### DIFF
--- a/uuid.go
+++ b/uuid.go
@@ -9,6 +9,7 @@ package uuid
 import (
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"net"
 	"os"
 
@@ -47,6 +48,18 @@ var (
 
 func init() {
 	flag.Var(&uuidPrefix, "uuid-prefix-file", "The file holding the UUID prefix for sockets created in this network namespace.")
+}
+
+// SetUUIDPrefix allows the prefix filename to be passed in via a function call
+// instead of via the command line. This function is useful for programs with
+// custom command lines that want to use this package.
+func SetUUIDPrefix(filename string) error {
+	fileContents, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return err
+	}
+	uuidPrefix = fileContents
+	return nil
 }
 
 // getCookie returns the cookie (the UUID) associated with a socket. For a given

--- a/uuid.go
+++ b/uuid.go
@@ -50,10 +50,10 @@ func init() {
 	flag.Var(&uuidPrefix, "uuid-prefix-file", "The file holding the UUID prefix for sockets created in this network namespace.")
 }
 
-// SetUUIDPrefix allows the prefix filename to be passed in via a function call
-// instead of via the command line. This function is useful for programs with
-// custom command lines that want to use this package.
-func SetUUIDPrefix(filename string) error {
+// SetUUIDPrefixFile allows the prefix filename to be passed in via a function
+// call instead of via the command line. This function is useful for programs
+// with custom command lines that want to use this package.
+func SetUUIDPrefixFile(filename string) error {
 	fileContents, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return err

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -1,0 +1,36 @@
+package uuid
+
+import (
+    "os"
+    "testing"
+)
+
+func TestSetUUIDPrefixFile(t *testing.T) {
+    expected := []byte("host.example.com_1552945174")
+    f, err :=  os.CreateTemp("", "")
+    if err != nil {
+        t.Error(err)
+    }
+    defer os.Remove(f.Name())
+    if _, err = f.Write(expected); err != nil {
+        t.Error(err)
+    }
+    if err = f.Close(); err != nil {
+        t.Error(err)
+    }
+
+    err = SetUUIDPrefixFile(f.Name())
+    if err != nil {
+        t.Error(err)
+    }
+    if string(uuidPrefix) != string(expected) {
+        t.Errorf("Expected '%s', got '%s'", string(expected), string(uuidPrefix))
+    }
+}
+
+func TestSetUUIDPrefixFileError(t *testing.T) {
+    err := SetUUIDPrefixFile("INVALID_FILENAME")
+    if err == nil {
+        t.Error("Expected error for invalid file, but got none.")
+    }
+}


### PR DESCRIPTION
Passing in the prefix file via a command line argument may not be optimal for programs with complex command lines. This addition allows programs to pass in the prefix file via a function call.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/uuid/15)
<!-- Reviewable:end -->
